### PR TITLE
Hotfix : Meta tag Encoding 문제

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -41,6 +41,7 @@ export const meta: MetaFunction = ({ params }) => {
   const isURL = `https://jaehan.blog/${post === undefined ? '' : post}`;
 
   return {
+    charset: 'utf-8',
     viewport: 'width=device-width',
     title: isTitle,
     description: isDescription,
@@ -80,8 +81,15 @@ export default function App() {
   return (
     <html lang="ko">
       <head>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
         <Meta />
         <Links />
+        <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+        <link
+          href="https://cdn.jsdelivr.net/gh/toss/tossface/dist/tossface.css"
+          rel="stylesheet"
+          type="text/css"
+        />
       </head>
       <body>
         <Suspense fallback={<>로딩 중...</>}>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -82,12 +82,6 @@ export default function App() {
       <head>
         <Meta />
         <Links />
-        <link rel="manifest" href="/manifest.json" />
-        <link
-          href="https://cdn.jsdelivr.net/gh/toss/tossface/dist/tossface.css"
-          rel="stylesheet"
-          type="text/css"
-        />
       </head>
       <body>
         <Suspense fallback={<>로딩 중...</>}>

--- a/app/routes/[robots.txt].tsx
+++ b/app/routes/[robots.txt].tsx
@@ -2,9 +2,6 @@ export const loader = () => {
   // handle "GET" request
   // set up our text content that will be returned in the response
   const robotText = `
-    User-agent: Googlebot
-    Allow: /public/
-
     User-agent: *
     Allow: /
 

--- a/app/styles/global.css
+++ b/app/styles/global.css
@@ -20,9 +20,9 @@
     color: #333;
     line-height: 180%;
 
-    font-family: 'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui,
-      Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic',
-      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
+    font-family: 'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, Tossface,
+      system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR',
+      'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
     /* Blocked IOS touch interactions */
     -webkit-tap-highlight-color: transparent;
 

--- a/app/styles/global.css
+++ b/app/styles/global.css
@@ -21,8 +21,8 @@
     line-height: 180%;
 
     font-family: 'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui,
-      Tossface, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR',
-      'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
+      Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic',
+      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
     /* Blocked IOS touch interactions */
     -webkit-tap-highlight-color: transparent;
 


### PR DESCRIPTION
- 문자가 깨져 출력되는 인코딩 문제 발생
- `<meta>` tag에 `charset='utf-8'`추가하여 문자 인코딩 지정 후 해결