### PR TITLE
fix : Image 경로 Firebase Storage에서 GCP로 변경

### DIFF
--- a/src/features/post/api/firebase/uploadImage.ts
+++ b/src/features/post/api/firebase/uploadImage.ts
@@ -26,29 +26,42 @@ export default async function uploadImage(props: Props): Promise<string> {
   const response = await fetch(isSrc);
   const data = await response.arrayBuffer();
 
+  // 확장자
   const ext = isSrc.includes('unsplash')
     ? String(isSrc.split('fm=').pop()).split('&').shift()
     : String(isSrc.split('.').pop()).split('?').shift();
+
+  // 파일 이름
   const filename = decodeURIComponent(
     String(String(isSrc.split('/').pop()).split('?').shift())
       .split('.')
       .shift()!,
   );
+
+  // 메타데이터
   const metadata = {
     cacheControl: 'public, max-age=31556952, s-maxage=31556952, immutable',
     contentType: `image/${ext}`,
   };
+
+  // 유닉스 타임
   const hashTime = new Date().getTime();
 
   const collectionRef = ref(
     storage,
     `${collection}/${category}/${title}/${filename}-${hashTime}.${ext}`,
   );
-  const ImgUrl = await uploadBytes(collectionRef, data, metadata).then(async () => {
+
+  // firebase에 올린 파일 주소 얻기
+  const imgFirebaseUrl = await uploadBytes(collectionRef, data, metadata).then(async () => {
     Logger.update(`${filename}-${hashTime}.${ext}`);
     const url = await getDownloadURL(collectionRef);
     return url;
   });
 
-  return ImgUrl;
+  // GCP 주소로 변환
+  const imgPath = imgFirebaseUrl.split('jaehan-flow.appspot.com/o/')[1].split('?')[0];
+  const imgGcpUrl = `https://storage.googleapis.com/jaehan-flow.appspot.com/${imgPath}`;
+
+  return imgGcpUrl;
 }


### PR DESCRIPTION
- firebase storage 경로를 사용한다면 어떠한 이유로 인해 속도가 저하됨
- GCP 경로로 변경하여 속도 단축