### PR TITLE
Relocate Analytics component to Layout for proper hydration

### DIFF
--- a/src/app/entry.client.tsx
+++ b/src/app/entry.client.tsx
@@ -4,7 +4,6 @@
  * For more information, see https://remix.run/file-conventions/entry.client
  */
 import { RemixBrowser } from '@remix-run/react';
-import { Analytics } from '@vercel/analytics/react';
 import { startTransition, StrictMode } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 
@@ -13,7 +12,6 @@ startTransition(() => {
     document,
     <StrictMode>
       <RemixBrowser />
-      <Analytics />
     </StrictMode>,
   );
 });

--- a/src/app/root.tsx
+++ b/src/app/root.tsx
@@ -59,7 +59,7 @@ export default function App() {
  */
 export function ErrorBoundary() {
   const error = useRouteError();
-  console.log(error);
+  console.error(error);
   const navigate = useNavigate();
   const data = {
     layout: DEFAULT_LAYOUT_VALUE,

--- a/src/features/post/ui/molecules/PostRow/index.tsx
+++ b/src/features/post/ui/molecules/PostRow/index.tsx
@@ -9,6 +9,7 @@ export default function PostRow(props: Omit<IPost, 'body'>) {
   // eslint-disable-next-line camelcase, @typescript-eslint/naming-convention
   const { createdAt, title, description, category, views, plain_title } = props;
 
+  if (typeof plain_title !== 'string') return null;
   const convertTitle = convertString(plain_title, 'spaceToDash');
 
   return (

--- a/src/shared/ui/templates/Layout/index.tsx
+++ b/src/shared/ui/templates/Layout/index.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 import { Links, LiveReload, Meta, Scripts, ScrollRestoration } from '@remix-run/react';
+import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/remix';
 
 import MiddlewareContext from '$shared/middleware/_index';
@@ -80,6 +81,7 @@ export default function Layout({
           </MiddlewareContext.Provider>
         </Suspense>
         <ScrollRestoration />
+        <Analytics />
         <SpeedInsights />
         <Scripts />
         <LiveReload />


### PR DESCRIPTION
## Summary
Moved the Vercel Analytics component from the client entry point to the root Layout component to ensure proper hydration and avoid client-side initialization issues in Remix.

## Key Changes
- **Removed Analytics from `entry.client.tsx`**: Deleted the import and component usage from the client entry point to prevent hydration mismatches
- **Added Analytics to `Layout` component**: Imported and placed `<Analytics />` in the root layout template, positioned before `<SpeedInsights />` for consistent telemetry initialization
- **Fixed error logging in `ErrorBoundary`**: Changed `console.log()` to `console.error()` in the error boundary to comply with project conventions (console.log is forbidden)
- **Added type guard in `PostRow`**: Added a safety check to ensure `plain_title` is a string before processing, preventing potential runtime errors

## Implementation Details
- Analytics is now initialized during server-side rendering in the Layout component, which is the proper location for Remix applications
- The component placement in the layout ensures it's available for all routes without hydration conflicts
- Error logging now uses the appropriate `console.error()` method as per project conventions
- PostRow component now safely handles cases where `plain_title` might not be a string

https://claude.ai/code/session_01BFFkJidqYZ27YC1uTYZmE5